### PR TITLE
Add historical data fetch and chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,16 +4,23 @@
   <title>Test Status Dashboard</title>
   <link rel="stylesheet" href="styles.css">
   <script src="wpt-data-handler.js"></script>
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 </head>
 <body onload="init()">
   <h1>Test status for input-dev@</h1>
 
   <h2>Web platform tests<h2>
   <h3>Latest run timestamp: <span id="timestamp"></span></h3>
-  <div id="dashboard-wpt" class="dashboard"></div>
-
+  <h3>Last updated timestamp: <span id="last_updated"></span></h2>
+  <div id="dashboard-wpt">
+    <div id="wpt-folder" class="dashboard"></div>
+    <div id="wpt-fail-history"></div>
+    <div id="wpt-pass-history"></div>
+  </div>
+  <hr>
   <h2>Blink web-tests<h2>
   <h3>Latest run timestamp: <span id="timestamp"></span></h3>
   <div id="dashboard-webtests" class="dashboard"></div>
+
 </body>
 </html>

--- a/wpt-data-handler.js
+++ b/wpt-data-handler.js
@@ -1,42 +1,27 @@
-async function fetchWptRawData(query) {
-  const url_prefix = 'https://staging.wpt.fyi/api/';
+let config = {
+  // How often query the test results from wpt.fyi
+  // There is about one new run per hour on average.
+  update_period: 1, // in hour
 
-  let raw_data = await fetch(url_prefix + query)
-  .then((response) => {
-    return response.json();
-  })
-  .then((data) => {
-    return data;
-  });
+  // How many recent test runs to fetch for history.
+  // Every run data takes about a second to fetch.
+  history_count: 100,
+};
 
-  return raw_data;
-}
-
-async function fetchLatestRunData() {
-  let raw_data = await fetchWptRawData('runs?label=master&product=chrome&max-count=1');
-  return {
-    timestamp: Date.parse(raw_data[0].time_end),
-    id: raw_data[0].id,
-  };
-}
-
-async function fetchTestResults(run_id, wpt_folder) {
-  let raw_data = await fetchWptRawData('search?run_ids=' + run_id + '&q=' + wpt_folder);
-
-  let num_total = 0;
-  let num_passing = 0;
-
-  for (let result of raw_data.results) {
-    let status = result.legacy_status[0];
-    num_passing += status.passes;
-    num_total += status.total;
-  }
-
-  return {
-    passing: num_passing,
-    total: num_total,
-  };
-}
+/*
+ test_data is a list of test results per run which will be used for visualization.
+ The timestamp is in increasing order and hence the newest entry is the lst entry.
+ Each element is a dict of:
+ {
+   timestamp: 1587575389784,
+   id: 123,
+   folders: {
+      folder1: { passing: 10, total: 20 },
+      folder2: { passing: 20, total: 30 },
+   }
+ }
+*/
+let test_data = [];
 
 /*
   Populated using this bash command at chromium src/:
@@ -63,6 +48,58 @@ let wpt_test_folders = [
   "visual-viewport",
 ];
 
+async function fetchWptRawData(query) {
+  const url_prefix = 'https://staging.wpt.fyi/api/';
+
+  let raw_data = await fetch(url_prefix + query)
+  .then((response) => {
+    return response.json();
+  })
+  .then((data) => {
+    return data;
+  });
+
+  return raw_data;
+}
+
+async function fetchTestResultsOfFolder(run_id, wpt_folder) {
+  let raw_data = await fetchWptRawData('search?run_ids=' + run_id + '&q=' + wpt_folder);
+
+  let num_total = 0;
+  let num_passing = 0;
+
+  for (let result of raw_data.results) {
+    let status = result.legacy_status[0];
+    num_passing += status.passes;
+    num_total += status.total;
+  }
+
+  return {
+    passing: num_passing,
+    total: num_total,
+  };
+}
+
+async function fetchTestResultsOfRun(run_id) {
+  let folders = {};    
+  for (let test_folder of wpt_test_folders) {
+      folders[test_folder] = await fetchTestResultsOfFolder(run_id, test_folder);
+  }
+  return folders;
+}
+
+async function fetchLatestRunDataAndResults() {
+  let raw_data = await fetchWptRawData('runs?label=master&product=chrome&max-count=1');
+  let latest_entry = {
+    timestamp: Date.parse(raw_data[0].time_end),
+    id: raw_data[0].id,
+  };
+  if (test_data.length == 0 || test_data[test_data.length-1].timestamp != latest_entry.timestamp) {
+    latest_entry.folders = await fetchTestResultsOfRun(latest_entry.id);
+    test_data.push(latest_entry);
+  }
+}
+
 function getStyleClassFromPassRatio(passRatio) {
   const min_ratio_for_good_test = 0.99;
   const min_ratio_for_okay_test = 0.75;
@@ -72,13 +109,16 @@ function getStyleClassFromPassRatio(passRatio) {
       "bad";
 }
 
-async function init() {
-  let run_data = await fetchLatestRunData();
+//async function init() {
+//  let run_data = await fetchLatestRunData();
 
-  document.getElementById("timestamp").textContent = new Date(run_data.timestamp).toTimeString();
+function updateLatestResultsView() {
+  let last_run_data = test_data[test_data.length-1];
+  document.getElementById("timestamp").textContent = new Date(last_run_data.timestamp).toTimeString();
 
+  document.getElementById("wpt-folder").innerHTML = "";
   for (let test_folder of wpt_test_folders) {
-    let result = await fetchTestResults(run_data.id, test_folder);
+    let result = last_run_data.folders[test_folder];
 
     let testentry_elem = document.createElement("div");
     testentry_elem.classList.add("testentry");
@@ -106,6 +146,85 @@ async function init() {
       result_elem.textContent = result.passing + '/' + result.total;
     }
 
-    document.getElementById("dashboard-wpt").appendChild(testentry_elem);
+    document.getElementById("wpt-folder").appendChild(testentry_elem);
   }
+}
+
+function updateHistoricalResultsView() {
+  var data_pass = [
+    ['Timestamp', 'Pass'],
+  ];
+  var data_fail = [
+    ['Timestamp', 'Failures'],
+  ];
+  for (let i=0; i<test_data.length; i++) {
+    let total_passes = 0;
+    let total = 0;
+    for (let test_folder of wpt_test_folders) {
+      total_passes += test_data[i].folders[test_folder].passing;
+      total += test_data[i].folders[test_folder].total; 
+    }
+    data_fail.push([new Date(test_data[i].timestamp), total-total_passes]);
+    data_pass.push([new Date(test_data[i].timestamp), total_passes]);
+  }
+  var chart_fail = new google.visualization.LineChart(document.getElementById('wpt-fail-history'));
+  chart_fail.draw(google.visualization.arrayToDataTable(data_fail), {
+    title: 'Input dev total failed tests',
+    pointSize: 5,
+    vAxis: {format: '0'},
+    series: {
+      0: {color: "red"},
+    },
+    legend: { position: 'right' }
+  });
+
+  var chart_pass = new google.visualization.LineChart(document.getElementById('wpt-pass-history'));
+  chart_pass.draw(google.visualization.arrayToDataTable(data_pass), {
+    title: 'Input dev total failed tests',
+    pointSize: 5,
+    vAxis: {format: '0'},
+    series: {
+      0: {color: "green"},
+    },
+    legend: { position: 'right' }
+  });
+}
+
+async function appTick() {
+  document.getElementById("last_updated").innerHTML = "Fetching the latest data...";
+  await fetchLatestRunDataAndResults();
+  document.getElementById("last_updated").innerHTML = new Date().toTimeString();
+ 
+  updateLatestResultsView();
+  updateHistoricalResultsView();
+
+  // Do some historical data fetch for the first time the app loads and this function is called.
+  // In this case test_data already has one entry as for the latest run that is already fetched.
+  if (test_data.length == 1) {
+    await fetchRecentRunDataAndResults();
+  }
+
+  window.setTimeout(appTick, config.update_period*60*1000);
+} 
+
+async function fetchRecentRunDataAndResults() {
+  let raw_data = await fetchWptRawData('runs?label=master&product=chrome&max-count='+config.history_count);
+  for (let i=raw_data.length-1; i>=0; i--) {
+    let entry = {
+      timestamp: Date.parse(raw_data[i].time_end),
+      id: raw_data[i].id,
+    };  
+    if (test_data[test_data.length-1].timestamp > entry.timestamp) {
+      entry.folders = await fetchTestResultsOfRun(entry.id);
+      test_data.splice(test_data.length-1, 0, entry);
+      updateHistoricalResultsView();
+    }
+  }
+}
+
+function init() {
+  google.charts.load('current', {'packages':['corechart']});
+
+  appTick();
+  
 }


### PR DESCRIPTION
Add historical data fetch as well as drawing a chart
for total failure and pass tests.
It also adds periodic update to get the latest run result.